### PR TITLE
Update Luna example to use Gateway 11

### DIFF
--- a/gateway-luna-helm-sample/dockerfile/Dockerfile
+++ b/gateway-luna-helm-sample/dockerfile/Dockerfile
@@ -1,6 +1,6 @@
 # requires secret: hsm-server-secret (file that contains password for HSM_USER)
   
-# requires ARG: GW_IMAGE (example caapim/gateway:10.1.00)
+# requires ARG: GW_IMAGE (example caapim/gateway:11.0.00)
 # requires ARG: CLIENT_TAR_FILENAME (example 610-000401-003_SW_Linux_Luna_Minimal_Client_V10.3.0_RevA.tar)   
 # requires ARG: CLIENT_PATCH_TAR_FILENAME (example 630-000522-001_Sw_Patch_jsp_fix_for_jdk11_UC10.3.0_Custom_Release.tar) 
 # requires ARG: HSM_USER

--- a/gateway-luna-helm-sample/dockerfile/Dockerfile
+++ b/gateway-luna-helm-sample/dockerfile/Dockerfile
@@ -8,7 +8,7 @@
 # requires ARG: CERT_NAME
 # requires ARG: PARTITION_NAME
   
-ARG GW_IMAGE=caapim/gateway:10.1.00
+ARG GW_IMAGE=caapim/gateway:11.0.00
 ARG CENTOS_IMAGE=centos:centos7
   
 FROM ${CENTOS_IMAGE} AS luna-min-client
@@ -95,6 +95,15 @@ FROM ${GW_IMAGE} AS gateway
 
 ARG CLIENT_TAR_FILENAME
 
+#
+# Add tar to GW image
+#
+ENV MICRODNF_ARGS=--disablerepo=*\ --enablerepo=ubi-9-appstream-rpms\ --enablerepo=ubi-9-baseos-rpms\ --setopt\ install_weak_deps=0
+USER root
+RUN mkdir /var/cache/yum/
+RUN microdnf ${MICRODNF_ARGS} install -y --nodocs tar && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum
 # Add the luna client
 USER root
 COPY ${CLIENT_TAR_FILENAME} /tmp

--- a/gateway-luna-helm-sample/dockerfile/Dockerfile
+++ b/gateway-luna-helm-sample/dockerfile/Dockerfile
@@ -88,34 +88,27 @@ COPY ${CLIENT_PATCH_TAR_FILENAME} /tmp/patch/.
 # Extract patch to /tmp/patch
 RUN tar -xf /tmp/patch/${CLIENT_PATCH_TAR_FILENAME} --strip 1 -C /tmp/patch; rm -f /tmp/patch/${CLIENT_PATCH_TAR_FILENAME}
 
-#
-# Build new GW image with Luna client
-#
-FROM ${GW_IMAGE} AS gateway
-
-ARG CLIENT_TAR_FILENAME
-
-#
-# Add tar to GW image
-#
-ENV MICRODNF_ARGS=--disablerepo=*\ --enablerepo=ubi-9-appstream-rpms\ --enablerepo=ubi-9-baseos-rpms\ --setopt\ install_weak_deps=0
-USER root
-RUN mkdir /var/cache/yum/
-RUN microdnf ${MICRODNF_ARGS} install -y --nodocs tar && \
-    microdnf clean all && \
-    rm -rf /var/cache/yum
-# Add the luna client
-USER root
 COPY ${CLIENT_TAR_FILENAME} /tmp
 ENV LUNA_DIR /usr/local/luna
 RUN mkdir -p ${LUNA_DIR} \
   && tar xvf /tmp/${CLIENT_TAR_FILENAME} --strip 1 -C ${LUNA_DIR} \
   && rm -f /tmp/${CLIENT_TAR_FILENAME}
 
-COPY --from=luna-min-client "/home/luna-docker/config" "${LUNA_DIR}/config"
+RUN cp -r /home/luna-docker/config ${LUNA_DIR}/config
+
+
+#
+# Build new GW image with Luna client
+#
+FROM ${GW_IMAGE} AS gateway
+ARG CLIENT_TAR_FILENAME
+ENV LUNA_DIR /usr/local/luna
+USER root
+
+COPY --from=luna-min-client ${LUNA_DIR} ${LUNA_DIR}
+
 ENV ChrystokiConfigurationPath /usr/local/luna/config
 ENV PATH="${LUNA_DIR}/bin/64:${PATH}"
-
 
 # For non patched version, copy required jsp files from ${MIN_CLIENT_dir} directly
 #

--- a/gateway-luna-helm-sample/dockerfile/Dockerfile
+++ b/gateway-luna-helm-sample/dockerfile/Dockerfile
@@ -96,7 +96,6 @@ RUN mkdir -p ${LUNA_DIR} \
 
 RUN cp -r /home/luna-docker/config ${LUNA_DIR}/config
 
-
 #
 # Build new GW image with Luna client
 #

--- a/gateway-luna-helm-sample/dockerfile/README.md
+++ b/gateway-luna-helm-sample/dockerfile/README.md
@@ -2,8 +2,8 @@
 
 ## Description
 
-This sample Dockerfile builds a derived Gateway 11.0.00 CR2+ image that can connect to Luna HSM 7.  Note: GW 11.0.00 CR2 and higher Container Gateway uses UBI9 from Iron Bank base image.
-Any Linux commands that are no longer available with this change need to be installed using Mircodnf.
+This sample Dockerfile builds a derived Gateway image 11.0 that can connect to Luna HSM 7.  Note: GW 11.0.00 CR2 and higher Container Gateway uses UBI9 from Iron Bank base image.
+Linux packages that are no longer available in the derived image with this change may be added back using mircodnf.
 
 ## Prerequisites/Dependencies
 The Dockerfile has specific steps to install the Luna Client 10.3 + Luna Client jdk11 patch.  The following files are required from Thales:

--- a/gateway-luna-helm-sample/dockerfile/README.md
+++ b/gateway-luna-helm-sample/dockerfile/README.md
@@ -2,8 +2,8 @@
 
 ## Description
 
-This sample Dockerfile builds a derived Gateway image 11.0 that can connect to Luna HSM 7.  Note: GW 11.0.00 CR2 and higher Container Gateway uses UBI9 from Iron Bank base image.
-Linux packages that are no longer available in the derived image with this change may be added back using mircodnf.
+This sample Dockerfile builds a derived Gateway image 11.0 that can connect to Luna HSM 7.  It has been updated to work with the new 11.0.00 CR2 which uses the UBI9-minimal base image from Iron Bank.  This Dockerfile will likely work with 10.1 and 11.0 CR1 (which still use the CentOS7 base image) though it wasn't tested with those versions. For the UBI9-minimal base image, Linux packages that are no longer available 
+in the derived image may be added back using microdnf.
 
 ## Prerequisites/Dependencies
 The Dockerfile has specific steps to install the Luna Client 10.3 + Luna Client jdk11 patch.  The following files are required from Thales:

--- a/gateway-luna-helm-sample/dockerfile/README.md
+++ b/gateway-luna-helm-sample/dockerfile/README.md
@@ -1,7 +1,9 @@
 # Dockerfile for Gateway with Luna HSM Integration
 
 ## Description
-This sample Dockerfile builds a derived Gateway 10.1 image that can connect to Luna HSM 7.
+
+This sample Dockerfile builds a derived Gateway 11.0.00 CR2+ image that can connect to Luna HSM 7.  Note: GW 11.0.00 CR2 and higher Container Gateway uses UBI9 from Iron Bank base image.
+Any Linux commands that are no longer available with this change need to be installed using Mircodnf.
 
 ## Prerequisites/Dependencies
 The Dockerfile has specific steps to install the Luna Client 10.3 + Luna Client jdk11 patch.  The following files are required from Thales:


### PR DESCRIPTION
Update Luna integration example to show how to create a derived image of Gateway 11 with Luna Client.  In this update, more of the Luna client unpackaging is done in the first stage allowing the use of a Gateway image irrespective of the Gateway's base image.