### PR TITLE
[grafana-stack-prometheus-otel] new tempo datasource for SDK traces

### DIFF
--- a/grafana-stack-prometheus-otel/prometheus/grafana-dashboard/layer7-gateway-dashboard-minimal.json
+++ b/grafana-stack-prometheus-otel/prometheus/grafana-dashboard/layer7-gateway-dashboard-minimal.json
@@ -18,7 +18,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 30,
     "links": [],
     "liveNow": false,
     "panels": [
@@ -896,7 +895,7 @@
       {
         "datasource": {
           "type": "tempo",
-          "uid": "caa853f8-508d-47f2-a711-ad469652ab58"
+          "uid": "tempo-minimal"
         },
         "fieldConfig": {
           "defaults": {
@@ -951,7 +950,7 @@
           {
             "datasource": {
               "type": "tempo",
-              "uid": "caa853f8-508d-47f2-a711-ad469652ab58"
+              "uid": "cdkic3qq3h8g0c"
             },
             "filters": [
               {
@@ -1113,13 +1112,13 @@
       ]
     },
     "time": {
-      "from": "now-5m",
+      "from": "now-15m",
       "to": "now"
     },
     "timepicker": {},
     "timezone": "",
     "title": "Gateway Dashboard-Minimal",
     "uid": "K5qg2_15m",
-    "version": 5,
+    "version": 1,
     "weekStart": ""
   }

--- a/grafana-stack-prometheus-otel/prometheus/prometheus-values.yaml
+++ b/grafana-stack-prometheus-otel/prometheus/prometheus-values.yaml
@@ -78,7 +78,20 @@ grafana:
       editable: true
       orgId: 1
       type: prometheus
-      url: http://mimir-nginx.grafana-loki.svc.cluster.local/prometheus 
+      url: http://mimir-nginx.grafana-loki.svc.cluster.local/prometheus
+    - name: tempo-minimal
+      id: 6
+      editable: true
+      uid: tempo-minimal
+      orgId: 1
+      type: tempo
+      url: http://tempo.grafana-loki.svc.cluster.local:3100
+      version: 1
+      jsonData:
+        tracesToLogsV2:
+          customQuery: true
+          datasourceUid: P982945308D3682D1
+          filterByTraceID: true
 
   rbac:
     ## If true, Grafana PSPs will be created


### PR DESCRIPTION
Added a new datasource called tempo-minimal that works better with the minimal dashboard