### PR TITLE
DE619759 luna permission

### DIFF
--- a/gateway-luna-helm-sample/README.md
+++ b/gateway-luna-helm-sample/README.md
@@ -11,7 +11,9 @@ to build and run a derived Gateway container with embedded Luna HSM client softw
 * For running the Gateway image, refer to the apim-charts/gateway [prerequisites](https://github.com/CAAPIM/apim-charts/tree/gateway-3.0.5/charts/gateway#prerequisites)
 
 ## Build the derived Gateway image
-Follow the instructions in [dockerfile/README.md](dockerfile/README.md) to build the derived Gateway container
+* Follow the instructions in [dockerfile/README.md](dockerfile/README.md) to build the derived Gateway(11.0) container
+with the Luna client software installed.
+* Follow the instructions in [dockerfile-example-luna10-6/README.md](dockerfile/README.md) to build the derived Gateway(11.1 and above) container
 with the Luna client software installed.
 
 ## Deploying the Gateway
@@ -53,3 +55,6 @@ Then scale up as desired.
    ```
    kubectl scale deployments --namespace <NAMESPACE> <DEPLOYMENT-NAME>-gateway --replicas 1
    ```
+
+## Headless deployment in Kubernetes without Policy Manager(GW 11.1.2)
+Follow the instruction in [headelss-helm-example/README.md](dockerfile/README.md) to deploy derived GW(11.1.2).

--- a/gateway-luna-helm-sample/dockerfile-example-luna10-6/Dockerfile
+++ b/gateway-luna-helm-sample/dockerfile-example-luna10-6/Dockerfile
@@ -1,3 +1,4 @@
+# Copyright © 2025 Broadcom Inc. and its subsidiaries. All Rights Reserved.
 # requires secret: hsm-server-secret (file that contains password for HSM_USER)
   
 # requires ARG: GW_IMAGE (example caapim/gateway:11.1.1)
@@ -91,6 +92,7 @@ RUN cd $LUNA_DIR/libs/64 \
     && rm -f libCryptoki2_64.so \
     && ln -s libCryptoki2.so libCryptoki2_64.so
 
+RUN chmod -R 655 ${LUNA_DIR}
 #
 # Build new GW image with Luna client
 #
@@ -106,8 +108,8 @@ ENV PATH="${LUNA_DIR}/bin/64:${PATH}"
 
 # For non patched version, copy required jsp files from ${MIN_CLIENT_dir} directly
 #
-COPY --from=luna-min-client $LUNA_DIR/jsp/LunaProvider.jar /opt/SecureSpan/Gateway/runtime/lib/ext/
-COPY --from=luna-min-client $LUNA_DIR/jsp/64/libLunaAPI.so /opt/SecureSpan/Gateway/runtime/lib/ext/
+COPY --from=luna-min-client --chmod=755 $LUNA_DIR/jsp/LunaProvider.jar /opt/SecureSpan/Gateway/runtime/lib/ext/
+COPY --from=luna-min-client --chmod=755 $LUNA_DIR/jsp/64/libLunaAPI.so /opt/SecureSpan/Gateway/runtime/lib/ext/
 #
 # Update security provider order as required by Luna client.  This can be done either here or in the helm chart.
 # For this example, it is done in the helmchart so that the provider order can be reverted if there is a need

--- a/gateway-luna-helm-sample/dockerfile-example-luna10-6/README.md
+++ b/gateway-luna-helm-sample/dockerfile-example-luna10-6/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This sample Dockerfile builds a derived Gateway image 11.1 that can connect to Luna HSM 7.
+This sample Dockerfile builds a derived **Gateway image 11.1 and above** that can connect to Luna HSM 7.
 
 ## Prerequisites/Dependencies
 The Dockerfile has specific steps to install the Minimal Luna HSM Client 10.6 for Linux.  The following file are required from Thales:

--- a/gateway-luna-helm-sample/dockerfile-example-luna10-6/README.md
+++ b/gateway-luna-helm-sample/dockerfile-example-luna10-6/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This sample Dockerfile builds a derived **Gateway image 11.1 and above** that can connect to Luna HSM 7.
+This sample Dockerfile builds a derived Gateway image 11.1.1 that can connect to Luna HSM 7.
 
 ## Prerequisites/Dependencies
 The Dockerfile has specific steps to install the Minimal Luna HSM Client 10.6 for Linux.  The following file are required from Thales:

--- a/gateway-luna-helm-sample/dockerfile-example-luna10-6/README.md
+++ b/gateway-luna-helm-sample/dockerfile-example-luna10-6/README.md
@@ -37,3 +37,6 @@ To build the image:
 * Policy Manager must be used to enable HSM on the Gateway once the Gateway has been started.
 * For the simplicity of this sample, HSM client registration is done during image creation.  The registration steps can be moved out and be performed at a later time.
 * The HSM partition is specified during image creation.  Create a new image if a new partition is to be selected.
+
+Note:
+From GW11.1.2, Policy Manager is not required for Headless deployment. See headless-helm-example.

--- a/gateway-luna-helm-sample/dockerfile/Dockerfile
+++ b/gateway-luna-helm-sample/dockerfile/Dockerfile
@@ -1,3 +1,4 @@
+# Copyright © 2025 Broadcom Inc. and its subsidiaries. All Rights Reserved.
 # requires secret: hsm-server-secret (file that contains password for HSM_USER)
   
 # requires ARG: GW_IMAGE (example caapim/gateway:11.0.00)
@@ -95,6 +96,7 @@ RUN mkdir -p ${LUNA_DIR} \
   && rm -f /tmp/${CLIENT_TAR_FILENAME}
 
 RUN cp -r /home/luna-docker/config ${LUNA_DIR}/config
+RUN chmod -R 655 ${LUNA_DIR}
 
 #
 # Build new GW image with Luna client
@@ -111,8 +113,8 @@ ENV PATH="${LUNA_DIR}/bin/64:${PATH}"
 
 # For non patched version, copy required jsp files from ${MIN_CLIENT_dir} directly
 #
-COPY --from=luna-min-client /tmp/patch/LunaProvider.jar /opt/SecureSpan/Gateway/runtime/lib/ext/
-COPY --from=luna-min-client /tmp/patch/linux/64/libLunaAPI.so /opt/SecureSpan/Gateway/runtime/lib/ext/
+COPY --from=luna-min-client --chmod=755 /tmp/patch/LunaProvider.jar /opt/SecureSpan/Gateway/runtime/lib/ext/
+COPY --from=luna-min-client --chmod=755 /tmp/patch/linux/64/libLunaAPI.so /opt/SecureSpan/Gateway/runtime/lib/ext/
 
 #
 # Update security provider order as required by Luna client.  This can be done either here or in the helm chart.

--- a/gateway-luna-helm-sample/dockerfile/README.md
+++ b/gateway-luna-helm-sample/dockerfile/README.md
@@ -5,6 +5,8 @@
 This sample Dockerfile builds a derived Gateway image 11.0 that can connect to Luna HSM 7.  It has been updated to work with the new 11.0.00 CR2 which uses the UBI9-minimal base image from Iron Bank.  This Dockerfile will likely work with 10.1 and 11.0 CR1 (which still use the CentOS7 base image) though it wasn't tested with those versions. For the UBI9-minimal base image, Linux packages that are no longer available 
 in the derived image may be added back using microdnf.
 
+To build a derived **Gateway image 11.1 and above**, use dockerfile-example-luna10-6 as reference.
+
 ## Prerequisites/Dependencies
 The Dockerfile has specific steps to install the Luna Client 10.3 + Luna Client jdk11 patch.  The following files are required from Thales:
 
@@ -31,6 +33,9 @@ To build the image:
 6. Start up the container.  At this time, the Policy Manager must be used to enable the HSM Keystore. Click on Manage Private Keys / Manage Keystore/ Enable SafeNet HSM and enter the required information.
 
 7. Scale down and scale up the Gateway.  The Gateway is now using Luna HSM.
+
+Note:
+From **GW11.1.2**, Policy Manager is not required for Headless deployment. See headless-helm-example.
 
 ## Known Limitations
 

--- a/gateway-luna-helm-sample/headless-helm-example/README.md
+++ b/gateway-luna-helm-sample/headless-helm-example/README.md
@@ -1,0 +1,21 @@
+## Container GW Headless deployment in Kubernetes without Policy Manager(GW 11.1.2)
+1. Set disklessConfig.enabled to false. Create node.properites file with node.cluster.pass value set. Sample node.properties is for Derby configuration
+   Reference README for APIM Gateway charts GibHub Pages [Diskless Configuration](https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/README.md#diskless-configuration) for MySQL database configuration
+2. create Kubernetes Secret
+```
+   kubectl create secret generic gateway-secret --from-file=node.properties=./node.properties
+```
+3. Encrypt LunaPIN by OpenSSL, password is value from node.cluster.pass
+```
+   echo -n '<LunaPIN>' | openssl enc -e -aes-256-cbc -pbkdf2 -iter 600000 -saltlen 16 -pass pass:<gateway_cluster_passphrase> -a;history -d $(history 1)
+```
+4. Append the following system property to config.systemProperties and place encrypted LunaPIN to com.l7tech.encryptedLunaPin in luna_headless_value.yaml
+   #LUNA properties
+   com.l7tech.common.security.jceProviderEngineName=luna
+   com.l7tech.luna.installAsLeastPreference=true
+   com.l7tech.encryptedLunaPin='<EncryptedLunaPartitionPassword>'
+   com.l7tech.lunaPartitionLabel=development
+   com.l7tech.server.keyStore.defaultSsl.alias=-1:<alias of the default SSL key, the default is SSL>
+   com.l7tech.common.security.disableJceProviderFallback=false
+
+3. start the Gateway, The Gateway is now using Luna HSM as keystore.

--- a/gateway-luna-helm-sample/headless-helm-example/README.md
+++ b/gateway-luna-helm-sample/headless-helm-example/README.md
@@ -13,7 +13,9 @@ This sample helm chart requires a derived **Gateway image 11.1.2** that can conn
 ```
    kubectl create secret generic gateway-secret --from-file=node.properties=./node.properties
 ```
-3. Encrypt LunaPIN by OpenSSL(version 3.2 or above), password is value from node.cluster.pass
+3. Encrypt LunaPIN by OpenSSL, password is value from node.cluster.pass
+   
+   NOTE: Ensure to use openssl 3.2.x version for optimal compatibility.
 ```
    echo -n '<LunaPIN>' | openssl enc -e -aes-256-cbc -pbkdf2 -iter 600000 -saltlen 16 -pass pass:<gateway_cluster_passphrase> -a;history -d $(history 1)
 ```

--- a/gateway-luna-helm-sample/headless-helm-example/README.md
+++ b/gateway-luna-helm-sample/headless-helm-example/README.md
@@ -13,7 +13,7 @@ This sample helm chart requires a derived **Gateway image 11.1.2** that can conn
 ```
    kubectl create secret generic gateway-secret --from-file=node.properties=./node.properties
 ```
-3. Encrypt LunaPIN by OpenSSL, password is value from node.cluster.pass
+3. Encrypt LunaPIN by OpenSSL(version 3.2 or above), password is value from node.cluster.pass
 ```
    echo -n '<LunaPIN>' | openssl enc -e -aes-256-cbc -pbkdf2 -iter 600000 -saltlen 16 -pass pass:<gateway_cluster_passphrase> -a;history -d $(history 1)
 ```

--- a/gateway-luna-helm-sample/headless-helm-example/README.md
+++ b/gateway-luna-helm-sample/headless-helm-example/README.md
@@ -1,4 +1,8 @@
-## Container GW Headless deployment in Kubernetes without Policy Manager(GW 11.1.2)
+## Description
+
+This sample helm chart requires a derived **Gateway image 11.1.2** that can connect to Luna HSM 7.
+
+## Container GW Headless deployment in Kubernetes without Policy Manager
 1. Set disklessConfig.enabled to false. Create node.properites file with node.cluster.pass value set. Sample node.properties is for Derby configuration
    Reference README for APIM Gateway charts GibHub Pages [Diskless Configuration](https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/README.md#diskless-configuration) for MySQL database configuration
 

--- a/gateway-luna-helm-sample/headless-helm-example/README.md
+++ b/gateway-luna-helm-sample/headless-helm-example/README.md
@@ -1,6 +1,10 @@
 ## Container GW Headless deployment in Kubernetes without Policy Manager(GW 11.1.2)
 1. Set disklessConfig.enabled to false. Create node.properites file with node.cluster.pass value set. Sample node.properties is for Derby configuration
    Reference README for APIM Gateway charts GibHub Pages [Diskless Configuration](https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/README.md#diskless-configuration) for MySQL database configuration
+
+   NOTE: Note that this can also be created with tools like [kustomize](https://kustomize.io/) which will be better for CI/CD pipelines. 
+   You can also take advantage of the secret [secret store csi driver](https://secrets-store-csi-driver.sigs.k8s.io/) to mount this secret from an external KMS provider.
+
 2. create Kubernetes Secret
 ```
    kubectl create secret generic gateway-secret --from-file=node.properties=./node.properties
@@ -10,6 +14,7 @@
    echo -n '<LunaPIN>' | openssl enc -e -aes-256-cbc -pbkdf2 -iter 600000 -saltlen 16 -pass pass:<gateway_cluster_passphrase> -a;history -d $(history 1)
 ```
 4. Append the following system property to config.systemProperties and place encrypted LunaPIN to com.l7tech.encryptedLunaPin in luna_headless_value.yaml
+
    #LUNA properties
    com.l7tech.common.security.jceProviderEngineName=luna
    com.l7tech.luna.installAsLeastPreference=true
@@ -18,4 +23,7 @@
    com.l7tech.server.keyStore.defaultSsl.alias=-1:<alias of the default SSL key, the default is SSL>
    com.l7tech.common.security.disableJceProviderFallback=false
 
-3. start the Gateway, The Gateway is now using Luna HSM as keystore.
+5. Deploy the Gateway. The Gateway is now using Luna HSM as keystore.
+   ```
+   helm install --set-file "license.value=helm-example/license.xml" --set "license.accept=true" --repo https://caapim.github.io/apim-charts/ <DEPLOYMENT-NAME> gateway --values headless-helm-example/luna_headless_value.yaml --namespace <NAMESPACE>
+   ```

--- a/gateway-luna-helm-sample/headless-helm-example/luna_headless_value.yaml
+++ b/gateway-luna-helm-sample/headless-helm-example/luna_headless_value.yaml
@@ -1,0 +1,82 @@
+license:
+  accept: true
+
+disklessConfig:
+  enabled: false
+  existingSecret:
+    name: gateway-secret
+
+image:
+  registry: <YOUR_DOCKER_REGISTRY>
+  repository: <YOUR_DOCKER_REGISTRY>
+  tag: <TAG>
+  pullPolicy: IfNotPresent
+
+imagePullSecret:
+  enabled: true
+  existingSecretName: mysecret
+#  username:
+#  password:
+
+management:
+  restman:
+    enabled: true
+  password: autotest
+  service:
+    enabled: false
+
+database:
+  enabled: false
+  create: false
+
+
+config:
+  javaArgs:
+    - -Dcom.l7tech.bootstrap.autoTrustSslKey=trustAnchor,TrustedFor.SSL,TrustedFor.SAML_ISSUER
+    - -Dcom.l7tech.server.audit.message.saveToInternal=false
+    - -Dcom.l7tech.server.audit.admin.saveToInternal=false
+    - -Dcom.l7tech.server.audit.system.saveToInternal=false
+    - -Dcom.l7tech.server.audit.log.format=json
+    - -Djava.util.logging.config.file=/opt/SecureSpan/Gateway/node/default/etc/conf/log-override.properties
+    - -Dcom.l7tech.server.pkix.useDefaultTrustAnchors=true
+    - -Dcom.l7tech.security.ssl.hostAllowWildcard=true
+    - -Djava.library.path=/opt/SecureSpan/Gateway/runtime/lib/ext
+    - -Djava.security.properties=/opt/SecureSpan/Gateway/runtime/etc/ssg.security
+  systemProperties: |-
+    # Default Gateway system properties
+    # Configuration properties for shared state extensions.
+    com.l7tech.server.extension.sharedKeyValueStoreProvider=embeddedhazelcast
+    com.l7tech.server.extension.sharedCounterProvider=ssgdb
+    com.l7tech.server.extension.sharedClusterInfoProvider=ssgdb
+    # By default, FIPS module will block an RSA modulus from being used for encryption if it has been used for
+    # signing, or visa-versa. Set true to disable this default behaviour and remain backwards compatible.
+    com.l7tech.org.bouncycastle.rsa.allow_multi_use=true
+    # Specifies the type of Trust Store (JKS/PKCS12) provided by AdoptOpenJDK that is used by Gateway.
+    # Must be set correctly when Gateway is running in FIPS mode. If not specified it will default to PKCS12.
+    javax.net.ssl.trustStoreType=jks
+    # Period of time before the Gateway removes inactive nodes.
+    com.l7tech.server.clusterStaleNodeCleanupTimeoutSeconds=86400
+    # Redis configuration - uncomment to use Redis
+    # com.l7tech.server.extension.sharedKeyValueStoreProvider=redis
+    # com.l7tech.server.extension.sharedCounterProvider=redis
+    # com.l7tech.server.extension.sharedRateLimiterProvider=redis
+    # Shared state provider preview settings
+    # com.l7tech.external.assertions.keyvaluestore.sharedKeyValueStoreProvider=redis
+    # com.l7tech.external.assertions.keyvaluestore.storeIdList=GW_STORE_ID
+    # If you would like to use the built in OpenTelemetry SDK uncomment and set the following configuration
+    # otel.sdk.disabled=false
+    # otel.java.global-autoconfigure.enabled=true
+    # otel.service.name=ssg-gateway
+    # otel.exporter.otlp.endpoint=http://localhost:4318/
+    # otel.exporter.otlp.protocol=http/protobuf
+    # otel.traces.exporter=otlp
+    # otel.metrics.exporter=otlp
+    # otel.logs.exporter=none
+    # Additional properties go here
+    #LUNA properties
+    com.l7tech.common.security.jceProviderEngineName=luna
+    com.l7tech.luna.installAsLeastPreference=true
+    com.l7tech.encryptedLunaPin='<OpenSSLEncryptedLunaPartitionPassword>'
+    com.l7tech.lunaPartitionLabel=<lunaPartitionLabel>
+    com.l7tech.server.keyStore.defaultSsl.alias=-1:<default SSL Key alias for SafeNet HSM keystore set by PM, default is SSL>  
+    com.l7tech.common.security.disableJceProviderFallback=false

--- a/gateway-luna-helm-sample/headless-helm-example/node.properties
+++ b/gateway-luna-helm-sample/headless-helm-example/node.properties
@@ -1,0 +1,5 @@
+node.cluster.pass=mypassword
+admin.user=admin
+admin.pass=mypassword
+node.db.type=derby
+node.db.config.main.user=gateway


### PR DESCRIPTION
DE619759, Update Dockerfile to match the permission of the appliance and software gateway for images derived from all supported container GW version
US991353, add headless deployment sample for GW11.1.2
Update README of samples for the supported GW versions.

