### PR TITLE
add dockerfile example for adding packages to 11.1.2+ Gateway

### DIFF
--- a/gateway-ubi9-micro-install-packages-sample/README.md
+++ b/gateway-ubi9-micro-install-packages-sample/README.md
@@ -1,0 +1,6 @@
+# Add Packages to Gateway Container
+
+## Description
+Layer 7 API Gateway container image 11.1.2 is built on ubi9-micro base image and it does not have a package manager installed. 
+The Dockerfile provides an example of how to add packages to the 11.1.2 container image.
+

--- a/gateway-ubi9-micro-install-packages-sample/README.md
+++ b/gateway-ubi9-micro-install-packages-sample/README.md
@@ -4,3 +4,6 @@
 The container image for Layer 7 API Gateway 11.1.2 is built on the ubi9-micro base image and does not have a package manager pre-installed. 
 The Dockerfile provides an example of how to add packages to the 11.1.2 container image.
 
+## Execute the following command to build the image:
+
+   `DOCKER_BUILDKIT=1 docker build -t <IMAGE_NAME> --no-cache --build-arg GW_IMAGE=<GATEWAY_IMAGE> -f Dockerfile .`

--- a/gateway-ubi9-micro-install-packages-sample/README.md
+++ b/gateway-ubi9-micro-install-packages-sample/README.md
@@ -1,6 +1,6 @@
 # Add Packages to Gateway Container
 
 ## Description
-Layer 7 API Gateway container image 11.1.2 is built on ubi9-micro base image and it does not have a package manager installed. 
+The container image for Layer 7 API Gateway 11.1.2 is built on the ubi9-micro base image and does not have a package manager pre-installed. 
 The Dockerfile provides an example of how to add packages to the 11.1.2 container image.
 

--- a/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
+++ b/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
@@ -4,12 +4,14 @@
 # There may have been OS packages that you rely on in pre-11.1.2 but are no longer available, this is due to the base change from ubi9-minimal to ubi9-micro
 # This dockerfile provides an example on how you can add packages back to your own version of the Layer 7 Gateway image
 
+ARG GW_IMAGE=caapim/gateway:latest
+
 ARG MICRODIR=/tmp/micro-root
 ARG MICROSRC=/tmp/source
 ARG MICROTGT=/tmp/target
 ARG ENTRYPOINT_UID=1001
 
-FROM caapim/gateway:latest AS base
+FROM ${GW_IMAGE} AS base
 
 # Use ubi9:latest image to run dnf and run rsync to find diff
 FROM redhat/ubi9:latest AS installer

--- a/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
+++ b/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
@@ -1,0 +1,62 @@
+# Copyright © 2025 Broadcom Inc. and its subsidiaries. All Rights Reserved.
+# Applicable to Layer 7 API Gateway Container release 11.1.2+
+
+# There may have been OS packages that you rely on in pre-11.1.2 but are no longer available, this is due to the base change from ubi9-minimal to ubi9-micro
+# This dockerfile provides an example on how you can add packages back to your own version of the Layer 7 Gateway image
+
+# Temporary location path to put the existing root directory of the official Layer 7 API Gateway image
+ARG MICRODIR=/tmp/gateway-root
+
+# Entrypoint user ID, this value has to be 1001
+ARG ENTRYPOINT_UID=1001
+
+# Layer 7 API Gateway image to build on
+ARG GATEWAY_IMAGE=caapim/gateway:latest
+
+# UBI9 image from redhat. This image will provide the dnf command utility to run package installation
+ARG UBI9=redhat/ubi9:latest
+
+# Establish the official Layer 7 API Gateway image as "base"
+FROM ${GATEWAY_IMAGE} AS base
+
+# Establish the redhat/ubi9:latest image as "utility-provider"
+FROM ${UBI9} AS utility-provider
+USER root
+
+# Make the temporary directory inside the redhat UBI9 image
+ARG MICRODIR
+RUN mkdir ${MICRODIR}
+
+# Copy the Layer 7 API Gateway image's (base) root directory into the created directory on the utility-provider
+COPY --from=base / ${MICRODIR}
+
+# Set dnf argument
+ENV DNF_ARGS=--releasever=9.5\ --disableplugin=subscription-manager\ --disablerepo=*\ --enablerepo=ubi-9-appstream-rpms\ --enablerepo=ubi-9-baseos-rpms
+
+# Run dnf command ( from redhat ubi9) to install packageNameA and packageNameB.
+# Change the root context to MICRODIR for dnf to use as a reference to figure out what dependencies are needed
+# Replace packageNameA and packageNameB with the package you want to install
+RUN <<EOF bash
+
+dnf ${DNF_ARGS} install \
+--nodocs --noplugins \
+--installroot ${MICRODIR} \
+--setopt=install_weak_deps=False \
+-y \
+packageNameA packageNameB
+dnf clean all \
+--installroot ${MICRODIR}
+EOF
+
+
+# Override the Layer 7 API Gateway image's root with the one in utility-provider
+FROM ${GATEWAY_IMAGE}
+
+USER root
+
+ARG ENTRYPOINT_UID
+ARG MICRODIR
+
+# Replace Layer 7 API Gateway's root directory with the content of MICRODIR
+COPY --from=utility-provider --chown=root:root ${MICRODIR} .
+USER ${ENTRYPOINT_UID}

--- a/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
+++ b/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
@@ -9,8 +9,11 @@ ARG GW_IMAGE=caapim/gateway:latest
 ARG MICRODIR=/tmp/micro-root
 ARG MICROSRC=/tmp/source
 ARG MICROTGT=/tmp/target
+
+# The UID cannot be modified
 ARG ENTRYPOINT_UID=1001
 
+# Create a Gateway image layer and call it 'base'
 FROM ${GW_IMAGE} AS base
 
 # Use ubi9:latest image to run dnf and run rsync to find diff
@@ -21,11 +24,12 @@ ARG MICRODIR
 ARG MICROSRC
 ARG MICROTGT
 
-# Copy Gateway into 2 directories, SRC and TGT for rsync to compare and find the changed files
+# Copy Gateway into 2 directories, SRC (source) and TGT (target). 'rsync' command uses them
+# to compare and find the changed files
 COPY --from=base / ${MICROSRC}
 COPY --from=base / ${MICROTGT}
 
-# Install rsync utility on ubi9:latest
+# Install 'rsync' utility on ubi9:latest
 RUN <<EOF bash
 dnf ${DNF_ARGS} install \
   --nodocs --noplugins \
@@ -33,16 +37,17 @@ dnf ${DNF_ARGS} install \
   -y \
   rsync
 
-# Directory to hold the changed files
+# A new directory to hold only the changed files/directories
 mkdir ${MICRODIR}
 
-# run dnf to install packages "sudo" and "passwd". Set SRC as the installroot
+# Run dnf to install packages. Set SRC as the installroot
+# Replace <package_A> and <package_B> with the package names. Ex. passwd
 dnf ${DNF_ARGS} install \
   --nodocs --noplugins \
   --installroot ${MICROSRC} \
   --setopt=install_weak_deps=False \
   -y \
-  sudo passwd
+  <package_A> <package_B>
 dnf clean all \
   --installroot ${MICROSRC}
 
@@ -58,7 +63,7 @@ rm -rf ${MICROSRC}/usr/share/gcc*/python
 rsync -avc --compare-dest=${MICROTGT} ${MICROSRC}/ ${MICRODIR}
 EOF
 
-
+# Add new files into the Gateway layer
 FROM base
 ARG MICRODIR
 ARG ENTRYPOINT_UID

--- a/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
+++ b/gateway-ubi9-micro-install-packages-sample/dockerfile/Dockerfile
@@ -4,59 +4,63 @@
 # There may have been OS packages that you rely on in pre-11.1.2 but are no longer available, this is due to the base change from ubi9-minimal to ubi9-micro
 # This dockerfile provides an example on how you can add packages back to your own version of the Layer 7 Gateway image
 
-# Temporary location path to put the existing root directory of the official Layer 7 API Gateway image
-ARG MICRODIR=/tmp/gateway-root
-
-# Entrypoint user ID, this value has to be 1001
+ARG MICRODIR=/tmp/micro-root
+ARG MICROSRC=/tmp/source
+ARG MICROTGT=/tmp/target
 ARG ENTRYPOINT_UID=1001
 
-# Layer 7 API Gateway image to build on
-ARG GATEWAY_IMAGE=caapim/gateway:latest
+FROM caapim/gateway:latest AS base
 
-# UBI9 image from redhat. This image will provide the dnf command utility to run package installation
-ARG UBI9=redhat/ubi9:latest
+# Use ubi9:latest image to run dnf and run rsync to find diff
+FROM redhat/ubi9:latest AS installer
 
-# Establish the official Layer 7 API Gateway image as "base"
-FROM ${GATEWAY_IMAGE} AS base
-
-# Establish the redhat/ubi9:latest image as "utility-provider"
-FROM ${UBI9} AS utility-provider
 USER root
-
-# Make the temporary directory inside the redhat UBI9 image
 ARG MICRODIR
-RUN mkdir ${MICRODIR}
+ARG MICROSRC
+ARG MICROTGT
 
-# Copy the Layer 7 API Gateway image's (base) root directory into the created directory on the utility-provider
-COPY --from=base / ${MICRODIR}
+# Copy Gateway into 2 directories, SRC and TGT for rsync to compare and find the changed files
+COPY --from=base / ${MICROSRC}
+COPY --from=base / ${MICROTGT}
 
-# Set dnf argument
-ENV DNF_ARGS=--releasever=9.5\ --disableplugin=subscription-manager\ --disablerepo=*\ --enablerepo=ubi-9-appstream-rpms\ --enablerepo=ubi-9-baseos-rpms
-
-# Run dnf command ( from redhat ubi9) to install packageNameA and packageNameB.
-# Change the root context to MICRODIR for dnf to use as a reference to figure out what dependencies are needed
-# Replace packageNameA and packageNameB with the package you want to install
+# Install rsync utility on ubi9:latest
 RUN <<EOF bash
-
 dnf ${DNF_ARGS} install \
---nodocs --noplugins \
---installroot ${MICRODIR} \
---setopt=install_weak_deps=False \
--y \
-packageNameA packageNameB
+  --nodocs --noplugins \
+  --setopt=install_weak_deps=False \
+  -y \
+  rsync
+
+# Directory to hold the changed files
+mkdir ${MICRODIR}
+
+# run dnf to install packages "sudo" and "passwd". Set SRC as the installroot
+dnf ${DNF_ARGS} install \
+  --nodocs --noplugins \
+  --installroot ${MICROSRC} \
+  --setopt=install_weak_deps=False \
+  -y \
+  sudo passwd
 dnf clean all \
---installroot ${MICRODIR}
+  --installroot ${MICROSRC}
+
+# Cleanup of unnecessary files
+rm -rf ${MICROSRC}/var/cache/*
+rm -rf ${MICROSRC}/var/log/*
+rm -rf ${MICROSRC}/run/*
+rm -rf ${MICROSRC}/etc/machine-id
+rm -rf ${MICROSRC}/usr/share/gcc*/python
+
+# Run rsync https://linux.die.net/man/1/rsync
+# archive mode (This is equivalent to -rlptgoD), verbose, and use checksum to determine diff
+rsync -avc --compare-dest=${MICROTGT} ${MICROSRC}/ ${MICRODIR}
 EOF
 
 
-# Override the Layer 7 API Gateway image's root with the one in utility-provider
-FROM ${GATEWAY_IMAGE}
+FROM base
+ARG MICRODIR
+ARG ENTRYPOINT_UID
 
 USER root
-
-ARG ENTRYPOINT_UID
-ARG MICRODIR
-
-# Replace Layer 7 API Gateway's root directory with the content of MICRODIR
-COPY --from=utility-provider --chown=root:root ${MICRODIR} .
+COPY --from=installer --chown=root:root ${MICRODIR} .
 USER ${ENTRYPOINT_UID}


### PR DESCRIPTION
11.1.2 Gateway does not have a package manager so microdnf command is not available. 

Provided a sample dockerfile that uses redhat/ubi9 to install packages onto the Gateway image

Dockerfile logic:

1. Use redhat/ubi9 image to run dnf and install packages. 
2. use rsync https://linux.die.net/man/1/rsync to figure out the changed files coming from the new installed packages and port those to a temporary location. 
3. Add those files from the temporary location into the Gateway image. 

This minimizes disk utilization and maintains the Gateway's original high image efficiency. ( docker dive )